### PR TITLE
release version 2.0.0. 

### DIFF
--- a/pylic/__version__.py
+++ b/pylic/__version__.py
@@ -1,1 +1,1 @@
-version = "1.2.6"
+version = "2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pylic"
-version = "1.2.6"
+version = "2.0.0"
 description = "Python license checker"
 authors = ["Sandro Huber <sandrochuber@gmail.com>"]
 license = "MIT License"


### PR DESCRIPTION
major change because of introduction of commands 'check' and 'list'. Simply calling 'pylic' will not check the licenses but rather show the help message now.