### PR TITLE
Adds ignore_packages config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ pip install pylic
 ## Configuration
 
 `pylic` needs be run in the directory where your `pyproject.toml` file is located. You can configure
-- `safe_licenses`: All licenses you concider safe for usage. The string comparison is case-insensitive.
+- `safe_licenses`: All licenses you consider safe for usage. The string comparison is case-insensitive.
 - `unsafe_packages`: If you rely on a package that does not come with a license you have to explicitly list it as such.
+- `ignore_packages`: Packages that will not be reported as unsafe even if they use a license not listed as safe.
 
 ```toml
 [tool.pylic]
@@ -31,6 +32,9 @@ safe_licenses = [
 ]
 unsafe_packages = [
     "unlicensedPackage",
+]
+ignore_packages = [
+    "ignoredPackage",
 ]
 ```
 
@@ -118,7 +122,7 @@ Use `pylic list` to list all installed packages and their corresponding licenses
 Required tools:
 - Poetry (https://python-poetry.org/)
 
-Run `poetry install` to install all necessary dependencies. Checkout the `[tool.taskipy.tasks]` (see [taskipy](https://github.com/illBeRoy/taskipy)) section in the `pyproject.toml` file for utily tasks. You can run these with `poetry run task <task>`.
+Run `poetry install` to install all necessary dependencies. Checkout the `[tool.taskipy.tasks]` (see [taskipy](https://github.com/illBeRoy/taskipy)) section in the `pyproject.toml` file for utility tasks. You can run these with `poetry run task <task>`.
 
 Creating a new release is as simple as:
 - Update `version` in the pyproject.toml and the `__version__.py` file.

--- a/pylic/cli/commands/check.py
+++ b/pylic/cli/commands/check.py
@@ -16,9 +16,9 @@ class CheckCommand(Command):
             self._show_help()
             return 1
 
-        safe_licenses, unsafe_packages = read_config()
+        safe_licenses, unsafe_packages, ignore_packages = read_config()
         installed_licenses = read_all_installed_licenses_metadata()
-        checker = LicenseChecker(safe_licenses, unsafe_packages, installed_licenses)
+        checker = LicenseChecker(safe_licenses, unsafe_packages, ignore_packages, installed_licenses)
 
         unnecessary_safe_licenses = checker.get_unnecessary_safe_licenses()
         unnecessary_unsafe_packages = checker.get_unnecessary_unsafe_packages()

--- a/pylic/cli/commands/check.py
+++ b/pylic/cli/commands/check.py
@@ -16,12 +16,13 @@ class CheckCommand(Command):
             self._show_help()
             return 1
 
-        safe_licenses, unsafe_packages, ignore_packages = read_config()
+        config = read_config()
         installed_licenses = read_all_installed_licenses_metadata()
-        checker = LicenseChecker(safe_licenses, unsafe_packages, ignore_packages, installed_licenses)
+        checker = LicenseChecker(config, installed_licenses)
 
         unnecessary_safe_licenses = checker.get_unnecessary_safe_licenses()
         unnecessary_unsafe_packages = checker.get_unnecessary_unsafe_packages()
+        unnecessary_ignore_packages = checker.get_unnecessary_ignore_packages()
         bad_unsafe_packages = checker.get_bad_unsafe_packages()
         missing_unsafe_packages = checker.get_missing_unsafe_packages()
         unsafe_licenses = checker.get_unsafe_licenses()
@@ -30,9 +31,10 @@ class CheckCommand(Command):
             [
                 unnecessary_safe_licenses,
                 unnecessary_unsafe_packages,
+                unnecessary_ignore_packages,
                 bad_unsafe_packages,
                 missing_unsafe_packages,
-                unsafe_licenses,
+                unsafe_licenses.found,
             ]
         ):
             if len(unnecessary_safe_licenses) > 0:
@@ -44,6 +46,11 @@ class CheckCommand(Command):
                 console_writer.line("Unsafe packages listed which are not installed:")
                 for unnecessary_unsafe_package in unnecessary_unsafe_packages:
                     console_writer.line(f"  {WARNING}{unnecessary_unsafe_package}{END_STYLE}")
+
+            if len(unnecessary_ignore_packages) > 0:
+                console_writer.line("Ignore packages listed which are not installed:")
+                for unnecessary_ignore_package in unnecessary_ignore_packages:
+                    console_writer.line(f"  {WARNING}{unnecessary_ignore_package}{END_STYLE}")
 
             if len(bad_unsafe_packages) > 0:
                 console_writer.line("Found unsafe packages with a known license. Instead allow these licenses explicitly:")
@@ -65,9 +72,9 @@ class CheckCommand(Command):
                         )
                     )
 
-            if len(unsafe_licenses) > 0:
+            if len(unsafe_licenses.found) > 0:
                 console_writer.line("Found unsafe licenses:")
-                for bad_license in unsafe_licenses:
+                for bad_license in unsafe_licenses.found:
                     console_writer.line(
                         (
                             f"  {BLUE}{bad_license['package']}{END_STYLE} {LABEL}({bad_license['version']}){END_STYLE}: "
@@ -76,6 +83,16 @@ class CheckCommand(Command):
                     )
 
             return 1
+
+        if len(unsafe_licenses.ignored) > 0:
+            console_writer.line("Ignored packages with unsafe licenses:")
+            for bad_license in unsafe_licenses.ignored:
+                console_writer.line(
+                    (
+                        f"  {BLUE}{bad_license['package']}{END_STYLE} {LABEL}({bad_license['version']}){END_STYLE}: "
+                        f"{WARNING}{bad_license['license']}{END_STYLE}"
+                    )
+                )
 
         console_writer.write_all_licenses_ok()
         return 0
@@ -90,3 +107,4 @@ class CheckCommand(Command):
         console_writer.line("  section of the pyproject.toml file.\n")
         console_writer.line(f"    - {BOLD}safe_licenses{END_STYLE}: Licenses considered to be valid.")
         console_writer.line(f"    - {BOLD}unsafe_packages{END_STYLE}: Packages without a license yet to be considered valid.")
+        console_writer.line(f"    - {BOLD}ignore_packages{END_STYLE}: Packages that are not considered at all.")

--- a/pylic/cli/commands/command.py
+++ b/pylic/cli/commands/command.py
@@ -6,4 +6,4 @@ class Command:
     token: str
 
     def handle(self, options: List[str]) -> int:
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover

--- a/pylic/license_checker.py
+++ b/pylic/license_checker.py
@@ -1,28 +1,33 @@
+from dataclasses import dataclass
 from typing import Dict, List, Optional
+
+from pylic.toml import AppConfig
+
+
+@dataclass
+class UnsafeLicenses:
+    found: List[Dict]
+    ignored: List[Dict]
 
 
 class LicenseChecker:
     def __init__(
         self,
-        safe_licenses: Optional[List[str]] = None,
-        unsafe_packages: Optional[List[str]] = None,
-        ignore_packages: Optional[List[str]] = None,
+        config: Optional[AppConfig] = None,
         installed_licenses: Optional[List[Dict]] = None,
     ) -> None:
-        self.safe_licenses = safe_licenses or []
-        self.unsafe_packages = unsafe_packages or []
-        self.ignore_packages = ignore_packages or []
+        self.config = config or AppConfig()
         self.installed_licenses = installed_licenses or []
 
     def get_unnecessary_safe_licenses(self) -> List[str]:
         installed_license_names = [license_info["license"].lower() for license_info in self.installed_licenses]
 
         unnecessary_safe_licenses = []
-        lower_safe_licenses = [safe_license.lower() for safe_license in self.safe_licenses]
+        lower_safe_licenses = [safe_license.lower() for safe_license in self.config.safe_licenses]
 
         for index, safe_license in enumerate(lower_safe_licenses):
             if safe_license not in installed_license_names:
-                unnecessary_safe_licenses.append(self.safe_licenses[index])
+                unnecessary_safe_licenses.append(self.config.safe_licenses[index])
 
         return unnecessary_safe_licenses
 
@@ -30,13 +35,25 @@ class LicenseChecker:
         installed_package_names = [license_info["package"].lower() for license_info in self.installed_licenses]
 
         unnecessary_unsafe_packages = []
-        lower_unsafe_packages = [unsafe_package.lower() for unsafe_package in self.unsafe_packages]
+        lower_unsafe_packages = [unsafe_package.lower() for unsafe_package in self.config.unsafe_packages]
 
         for index, unsafe_package in enumerate(lower_unsafe_packages):
             if unsafe_package not in installed_package_names:
-                unnecessary_unsafe_packages.append(self.unsafe_packages[index])
+                unnecessary_unsafe_packages.append(self.config.unsafe_packages[index])
 
         return unnecessary_unsafe_packages
+
+    def get_unnecessary_ignore_packages(self) -> List[str]:
+        installed_package_names = [license_info["package"].lower() for license_info in self.installed_licenses]
+
+        unnecessary_ignore_packages = []
+        lower_ignore_packages = [ignore_package.lower() for ignore_package in self.config.ignore_packages]
+
+        for index, ignore_package in enumerate(lower_ignore_packages):
+            if ignore_package not in installed_package_names:
+                unnecessary_ignore_packages.append(self.config.ignore_packages[index])
+
+        return unnecessary_ignore_packages
 
     def get_bad_unsafe_packages(self) -> List[Dict]:
         bad_unsafe_packages: List[Dict] = []
@@ -45,7 +62,7 @@ class LicenseChecker:
             license = license_info["license"]
             package = license_info["package"]
 
-            if package in self.unsafe_packages and license.lower() != "unknown":
+            if package in self.config.unsafe_packages and license.lower() != "unknown":
                 bad_unsafe_packages.append({"license": license, "package": package, "version": license_info["version"]})
 
         return bad_unsafe_packages
@@ -57,21 +74,27 @@ class LicenseChecker:
             license = license_info["license"]
             package = license_info["package"]
 
-            if license.lower() == "unknown" and package not in self.unsafe_packages:
+            if license.lower() == "unknown" and package not in self.config.unsafe_packages:
                 missing_unsafe_packages.append({"package": package, "version": license_info["version"]})
 
         return missing_unsafe_packages
 
-    def get_unsafe_licenses(self) -> List[Dict]:
-        unsafe_licenses: List[Dict] = []
-        lower_safe_licenses = [safe_license.lower() for safe_license in self.safe_licenses]
+    def get_unsafe_licenses(self) -> UnsafeLicenses:
+        found_licenses: List[Dict] = []
+        ignored_licenses: List[Dict] = []
 
-        for license_info in filter(lambda license_info: license_info["package"] not in self.ignore_packages, self.installed_licenses):
+        lower_safe_licenses = [safe_license.lower() for safe_license in self.config.safe_licenses]
+
+        for license_info in self.installed_licenses:
             license = license_info["license"]
 
             if license.lower() == "unknown" or license.lower() in lower_safe_licenses:
                 continue
 
-            unsafe_licenses.append({"license": license, "package": license_info["package"], "version": license_info["version"]})
+            datum = {"license": license, "package": license_info["package"], "version": license_info["version"]}
+            if license_info["package"] in self.config.ignore_packages:
+                ignored_licenses.append(datum)
+            else:
+                found_licenses.append(datum)
 
-        return unsafe_licenses
+        return UnsafeLicenses(found=found_licenses, ignored=ignored_licenses)

--- a/pylic/license_checker.py
+++ b/pylic/license_checker.py
@@ -6,10 +6,12 @@ class LicenseChecker:
         self,
         safe_licenses: Optional[List[str]] = None,
         unsafe_packages: Optional[List[str]] = None,
+        ignore_packages: Optional[List[str]] = None,
         installed_licenses: Optional[List[Dict]] = None,
     ) -> None:
         self.safe_licenses = safe_licenses or []
         self.unsafe_packages = unsafe_packages or []
+        self.ignore_packages = ignore_packages or []
         self.installed_licenses = installed_licenses or []
 
     def get_unnecessary_safe_licenses(self) -> List[str]:
@@ -64,7 +66,7 @@ class LicenseChecker:
         unsafe_licenses: List[Dict] = []
         lower_safe_licenses = [safe_license.lower() for safe_license in self.safe_licenses]
 
-        for license_info in self.installed_licenses:
+        for license_info in filter(lambda license_info: license_info["package"] not in self.ignore_packages, self.installed_licenses):
             license = license_info["license"]
 
             if license.lower() == "unknown" or license.lower() in lower_safe_licenses:

--- a/pylic/toml.py
+++ b/pylic/toml.py
@@ -3,7 +3,7 @@ from typing import Any, List, MutableMapping, Tuple
 import toml
 
 
-def read_config(filename: str = "pyproject.toml") -> Tuple[List[str], List[str]]:
+def read_config(filename: str = "pyproject.toml") -> Tuple[List[str], List[str], List[str]]:
     project_config = _read_pyproject_file(filename)
     pylic_config = project_config.get("tool", {}).get("pylic", {})
     safe_licenses: List[str] = pylic_config.get("safe_licenses", [])
@@ -12,8 +12,9 @@ def read_config(filename: str = "pyproject.toml") -> Tuple[List[str], List[str]]
         raise ValueError("'unknown' can't be an safe license. Whitelist the corresponding packages instead.")
 
     unsafe_packages: List[str] = pylic_config.get("unsafe_packages", [])
+    ignore_packages: List[str] = pylic_config.get("ignore_packages", [])
 
-    return (safe_licenses, unsafe_packages)
+    return (safe_licenses, unsafe_packages, ignore_packages)
 
 
 def _read_pyproject_file(filename: str) -> MutableMapping[str, Any]:

--- a/pylic/toml.py
+++ b/pylic/toml.py
@@ -1,9 +1,17 @@
-from typing import Any, List, MutableMapping, Tuple
+from dataclasses import dataclass, field
+from typing import Any, List, MutableMapping
 
 import toml
 
 
-def read_config(filename: str = "pyproject.toml") -> Tuple[List[str], List[str], List[str]]:
+@dataclass
+class AppConfig:
+    safe_licenses: List[str] = field(default_factory=list)
+    unsafe_packages: List[str] = field(default_factory=list)
+    ignore_packages: List[str] = field(default_factory=list)
+
+
+def read_config(filename: str = "pyproject.toml") -> AppConfig:
     project_config = _read_pyproject_file(filename)
     pylic_config = project_config.get("tool", {}).get("pylic", {})
     safe_licenses: List[str] = pylic_config.get("safe_licenses", [])
@@ -14,7 +22,11 @@ def read_config(filename: str = "pyproject.toml") -> Tuple[List[str], List[str],
     unsafe_packages: List[str] = pylic_config.get("unsafe_packages", [])
     ignore_packages: List[str] = pylic_config.get("ignore_packages", [])
 
-    return (safe_licenses, unsafe_packages, ignore_packages)
+    return AppConfig(
+        safe_licenses=safe_licenses,
+        unsafe_packages=unsafe_packages,
+        ignore_packages=ignore_packages,
+    )
 
 
 def _read_pyproject_file(filename: str) -> MutableMapping[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,90 +1,91 @@
 [tool.poetry]
-name = "pylic"
-version = "3.0.2"
-description = "A Python license checker"
 authors = ["Sandro Huber <sandrochuber@gmail.com>"]
+classifiers = ["Development Status :: 3 - Alpha"]
+description = "A Python license checker"
+homepage = "https://github.com/ubersan/pylic"
 keywords = ["cli", "license"]
 license = "MIT License"
+name = "pylic"
 readme = "README.md"
-homepage = "https://github.com/ubersan/pylic"
 repository = "https://github.com/ubersan/pylic"
-classifiers = ["Development Status :: 3 - Alpha"]
+version = "3.0.2"
 
 [tool.poetry.dependencies]
+importlib-metadata = "^4.11.3"
 python = "^3.7"
 toml = "^0.10.2"
-importlib-metadata = "^4.11.3"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"
 flake8 = "^3.9.2"
+isort = "^5.10.1"
 mypy = "^0.942"
-taskipy = "^1.10.1"
 pytest = "^7.1.2"
 pytest-cov = "^3.0.0"
 pytest-mock = "^3.7.0"
-isort = "^5.10.1"
+taskipy = "^1.10.1"
 types-toml = "^0.10.5"
 
 [tool.poetry.scripts]
 pylic = 'pylic.cli.app:main'
 
 [tool.taskipy.tasks]
-quality = "black . && flake8 --max-line-length 140 --count . && isort . && mypy ."
-test = "pytest --cov=./ --cov-report=xml"
 check_licenses = "python -m pylic check"
 get_current_version = "echo -n v$(sed '3q;d' pyproject.toml | awk '{print $3}' | tail -c +2 | head -c -2)"
+quality = "black . && flake8 --max-line-length 140 --count . && isort . && mypy ."
 release = " git tag $(task get_current_version) && git push origin $(task get_current_version)"
+test = "pytest --cov=./ --cov-report=xml"
 
 [tool.pylic]
 safe_licenses = [
-    "BSD License",
-    "Apache Software License",
-    "MIT License",
-    "Python Software Foundation License",
-    "Mozilla Public License 2.0 (MPL 2.0)"
+  "BSD License",
+  "Apache Software License",
+  "MIT License",
+  "Python Software Foundation License",
+  "Mozilla Public License 2.0 (MPL 2.0)",
 ]
 
 [tool.black]
 line_length = 140
 
 [tool.isort]
-multi_line_output = 3
-include_trailing_comma = "True"
-force_grid_wrap = 0
-use_parentheses = "True"
 ensure_newline_before_comments = "True"
+force_grid_wrap = 0
+include_trailing_comma = "True"
 line_length = 140
+multi_line_output = 3
+use_parentheses = "True"
 
 [tool.coverage.report]
 exclude_lines = [
-    "if __name__ == .__main__.:",
-    "from importlib_metadata import Distribution, distributions", # tested by integration tests
-    "app.run()",  # tested by integration tests
+  "if __name__ == .__main__.:",
+  "from importlib_metadata import Distribution, distributions", # tested by integration tests
+  "app.run()", # tested by integration tests
+  "pragma: no cover",
 ]
 
 [tool.mypy]
+check_untyped_defs = true
+disallow_any_unimported = false
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+explicit_package_bases = true
 files = ["pylic", "tests"]
 namespace_packages = true
-explicit_package_bases = true
-disallow_any_unimported = false
-disallow_untyped_calls = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-disallow_untyped_decorators = true
 no_implicit_optional = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_unused_configs = true
-warn_no_return = true
-warn_return_any = true
-warn_unreachable = true
-show_error_context = true
+pretty = true
 show_column_numbers = true
 show_error_codes = true
-pretty = true
+show_error_context = true
+warn_no_return = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0"]

--- a/tests/integration_tests/full_app_test.py
+++ b/tests/integration_tests/full_app_test.py
@@ -81,3 +81,50 @@ def test_correct_error_is_returned_when_bad_unsafe_package(mocker: MockerFixture
     # )
     # assert app.io.fetch_output() == ""
     # assert return_code == 1
+
+
+def test_correct_error_is_returned_when_no_such_command(mocker: MockerFixture) -> None:
+    read_pyproject_file(mocker, "tests/integration_tests/test_tomls/valid.toml")
+    sys.argv.clear()
+    sys.argv.append("pylic")
+    sys.argv.append("bogus")
+
+    try:
+        app()
+    except SystemExit as system_exit:
+        assert system_exit.code == 1
+
+
+def test_correct_error_is_returned_when_no_such_option(mocker: MockerFixture) -> None:
+    read_pyproject_file(mocker, "tests/integration_tests/test_tomls/valid.toml")
+    sys.argv.clear()
+    sys.argv.append("pylic")
+    sys.argv.append("--bogus")
+
+    try:
+        app()
+    except SystemExit as system_exit:
+        assert system_exit.code == 1
+
+
+def test_correct_error_is_returned_when_help_option(mocker: MockerFixture) -> None:
+    read_pyproject_file(mocker, "tests/integration_tests/test_tomls/valid.toml")
+    sys.argv.clear()
+    sys.argv.append("pylic")
+    sys.argv.append("--help")
+
+    try:
+        app()
+    except SystemExit as system_exit:
+        assert system_exit.code == 1
+
+
+def test_correct_error_is_returned_when_no_tokens(mocker: MockerFixture) -> None:
+    read_pyproject_file(mocker, "tests/integration_tests/test_tomls/valid.toml")
+    sys.argv.clear()
+    sys.argv.append("pylic")
+
+    try:
+        app()
+    except SystemExit as system_exit:
+        assert system_exit.code == 1

--- a/tests/unit_tests/cli/commands/check_test.py
+++ b/tests/unit_tests/cli/commands/check_test.py
@@ -4,35 +4,47 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from pylic.cli.commands import check as check_module
 from pylic.cli.commands.check import CheckCommand
+from pylic.toml import AppConfig
 
 
 @pytest.fixture
 def console_writer(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("pylic.cli.commands.check.console_writer")
+    return mocker.patch.object(check_module, "console_writer")
 
 
-@pytest.fixture
-def check_command() -> CheckCommand:
-    return CheckCommand()
+@pytest.fixture(autouse=True)
+def read_config(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch.object(check_module, "read_config", MagicMock(return_value=AppConfig([], [], [])))
 
 
-def test_check_is_valid_if_no_packages_are_installed_and_config_is_empty(
-    mocker: MockerFixture, check_command: CheckCommand, console_writer: MagicMock
-) -> None:
-    mocker.patch("pylic.cli.commands.check.read_config", return_value=([], [], []))
-    mocker.patch("pylic.cli.commands.check.read_all_installed_licenses_metadata", return_value=[])
+@pytest.fixture(autouse=True)
+def read_all_installed_licenses_metadata(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch.object(check_module, "read_all_installed_licenses_metadata", MagicMock(return_value=[]))
+
+
+def test_help(check_command: CheckCommand, console_writer: MagicMock) -> None:
+    return_code = check_command.handle(["help"])
+    assert return_code == 1
+    console_writer.line.assert_called()
+    assert "USAGE" in console_writer.line.call_args_list[0][0][0]
+
+
+def test_check_is_valid_if_no_packages_are_installed_and_config_is_empty(check_command: CheckCommand, console_writer: MagicMock) -> None:
     return_code = check_command.handle([])
     assert return_code == 0
     console_writer.write_all_licenses_ok.assert_called()
 
 
 def test_check_yields_correct_unnecessary_safe_licenses(
-    mocker: MockerFixture, check_command: CheckCommand, license: str, console_writer: MagicMock
+    check_command: CheckCommand,
+    license: str,
+    console_writer: MagicMock,
+    read_config: MagicMock,
 ) -> None:
     safe_licenses = [f"{license}1", f"{license}2"]
-    mocker.patch("pylic.cli.commands.check.read_config", return_value=(safe_licenses, [], []))
-    mocker.patch("pylic.cli.commands.check.read_all_installed_licenses_metadata", return_value=[])
+    read_config.return_value = AppConfig(safe_licenses, [], [])
     return_code = check_command.handle([])
     assert return_code == 1
     lines = list(map(lambda line: cast(str, line[0][0]), console_writer.line.call_args_list))
@@ -43,12 +55,15 @@ def test_check_yields_correct_unnecessary_safe_licenses(
 
 @pytest.mark.parametrize("package_ignored", [True, False])
 def test_check_yields_correct_unnecessary_unsafe_packages(
-    mocker: MockerFixture, check_command: CheckCommand, package: str, console_writer: MagicMock, package_ignored: bool
+    check_command: CheckCommand,
+    package: str,
+    console_writer: MagicMock,
+    package_ignored: bool,
+    read_config: MagicMock,
 ) -> None:
     unsafe_packages = [f"{package}1", f"{package}2"]
     ignore_packages = [unsafe_packages[0]] if package_ignored else []
-    mocker.patch("pylic.cli.commands.check.read_config", return_value=([], unsafe_packages, ignore_packages))
-    mocker.patch("pylic.cli.commands.check.read_all_installed_licenses_metadata", return_value=[])
+    read_config.return_value = AppConfig([], unsafe_packages, ignore_packages)
     return_code = check_command.handle([])
     assert return_code == 1
     lines = list(map(lambda line: cast(str, line[0][0]), console_writer.line.call_args_list))
@@ -57,21 +72,38 @@ def test_check_yields_correct_unnecessary_unsafe_packages(
     assert f"{package}2" in lines[2]
 
 
+def test_check_yields_correct_unnecessary_ignore_packages(
+    check_command: CheckCommand,
+    package: str,
+    console_writer: MagicMock,
+    read_config: MagicMock,
+) -> None:
+    ignore_packages = [f"{package}1", f"{package}2"]
+    read_config.return_value = AppConfig([], [], ignore_packages)
+    return_code = check_command.handle([])
+    assert return_code == 1
+    lines = list(map(lambda line: cast(str, line[0][0]), console_writer.line.call_args_list))
+    assert lines[0] == "Ignore packages listed which are not installed:"
+    assert f"{package}1" in lines[1]
+    assert f"{package}2" in lines[2]
+
+
 @pytest.mark.parametrize("package_ignored", [True, False])
 def test_check_yields_correct_bad_unsafe_packages(
-    mocker: MockerFixture,
     check_command: CheckCommand,
     package: str,
     license: str,
     version: str,
     console_writer: MagicMock,
     package_ignored: bool,
+    read_config: MagicMock,
+    read_all_installed_licenses_metadata: MagicMock,
 ) -> None:
     unsafe_packages = [f"{package}"]
     ignore_packages = unsafe_packages if package_ignored else []
     installed_licenses = [{"package": f"{package}", "license": license, "version": version}]
-    mocker.patch("pylic.cli.commands.check.read_config", return_value=([license], unsafe_packages, ignore_packages))
-    mocker.patch("pylic.cli.commands.check.read_all_installed_licenses_metadata", return_value=installed_licenses)
+    read_config.return_value = AppConfig([license], unsafe_packages, ignore_packages)
+    read_all_installed_licenses_metadata.return_value = installed_licenses
     return_code = check_command.handle([])
     assert return_code == 1
     lines = list(map(lambda line: cast(str, line[0][0]), console_writer.line.call_args_list))
@@ -83,12 +115,18 @@ def test_check_yields_correct_bad_unsafe_packages(
 
 @pytest.mark.parametrize("package_ignored", [True, False])
 def test_check_yields_correct_missing_unsafe_packages(
-    mocker: MockerFixture, check_command: CheckCommand, package: str, version: str, console_writer: MagicMock, package_ignored: bool
+    check_command: CheckCommand,
+    package: str,
+    version: str,
+    console_writer: MagicMock,
+    package_ignored: bool,
+    read_config: MagicMock,
+    read_all_installed_licenses_metadata: MagicMock,
 ) -> None:
     ignore_packages = [f"{package}"] if package_ignored else []
     installed_licenses = [{"package": f"{package}", "license": "unknown", "version": version}]
-    mocker.patch("pylic.cli.commands.check.read_config", return_value=([], [], ignore_packages))
-    mocker.patch("pylic.cli.commands.check.read_all_installed_licenses_metadata", return_value=installed_licenses)
+    read_config.return_value = AppConfig([], [], ignore_packages)
+    read_all_installed_licenses_metadata.return_value = installed_licenses
     return_code = check_command.handle([])
     assert return_code == 1
     lines = list(map(lambda line: cast(str, line[0][0]), console_writer.line.call_args_list))
@@ -98,11 +136,17 @@ def test_check_yields_correct_missing_unsafe_packages(
 
 
 def test_check_yields_correct_unsafe_licenses(
-    mocker: MockerFixture, check_command: CheckCommand, package: str, license: str, version: str, console_writer: MagicMock
+    check_command: CheckCommand,
+    package: str,
+    license: str,
+    version: str,
+    console_writer: MagicMock,
+    read_config: MagicMock,
+    read_all_installed_licenses_metadata: MagicMock,
 ) -> None:
     installed_licenses = [{"package": f"{package}", "license": license, "version": version}]
-    mocker.patch("pylic.cli.commands.check.read_config", return_value=([], [], []))
-    mocker.patch("pylic.cli.commands.check.read_all_installed_licenses_metadata", return_value=installed_licenses)
+    read_config.return_value = AppConfig([], [], [])
+    read_all_installed_licenses_metadata.return_value = installed_licenses
     return_code = check_command.handle([])
     assert return_code == 1
     lines = list(map(lambda line: cast(str, line[0][0]), console_writer.line.call_args_list))
@@ -113,12 +157,23 @@ def test_check_yields_correct_unsafe_licenses(
 
 
 def test_check_yields_correct_unsafe_licenses_when_packages_ignored(
-    mocker: MockerFixture, check_command: CheckCommand, package: str, license: str, version: str, console_writer: MagicMock
+    check_command: CheckCommand,
+    package: str,
+    license: str,
+    version: str,
+    console_writer: MagicMock,
+    read_config: MagicMock,
+    read_all_installed_licenses_metadata: MagicMock,
 ) -> None:
     ignore_packages = [f"{package}"]
     installed_licenses = [{"package": f"{package}", "license": license, "version": version}]
-    mocker.patch("pylic.cli.commands.check.read_config", return_value=([], [], ignore_packages))
-    mocker.patch("pylic.cli.commands.check.read_all_installed_licenses_metadata", return_value=installed_licenses)
+    read_config.return_value = AppConfig([], [], ignore_packages)
+    read_all_installed_licenses_metadata.return_value = installed_licenses
     return_code = check_command.handle([])
     assert return_code == 0
     console_writer.write_all_licenses_ok.assert_called()
+    lines = list(map(lambda line: cast(str, line[0][0]), console_writer.line.call_args_list))
+    assert lines[0] == "Ignored packages with unsafe licenses:"
+    assert package in lines[1]
+    assert version in lines[1]
+    assert license in lines[1]

--- a/tests/unit_tests/cli/commands/list_test.py
+++ b/tests/unit_tests/cli/commands/list_test.py
@@ -4,29 +4,32 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from pylic.cli.commands import list as list_module
 from pylic.cli.commands.list import ListCommand
 from tests.unit_tests.conftest import random_string
 
 
 @pytest.fixture
 def console_writer(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("pylic.cli.commands.list.console_writer")
+    return mocker.patch.object(list_module, "console_writer")
 
 
-@pytest.fixture
-def list_commandd() -> ListCommand:
-    return ListCommand()
+def test_help(list_command: ListCommand, console_writer: MagicMock) -> None:
+    return_code = list_command.handle(["help"])
+    assert return_code == 1
+    console_writer.line.assert_called()
+    assert "USAGE" in console_writer.line.call_args_list[0][0][0]
 
 
 def test_yields_correct_and_alphabetically_sorted_package_list(
-    mocker: MockerFixture, list_commandd: ListCommand, license: str, version: str, console_writer: MagicMock
+    mocker: MockerFixture, list_command: ListCommand, license: str, version: str, console_writer: MagicMock
 ) -> None:
     number_of_packages = 10
     license_metadata = [
         {"package": f"{random_string()}", "license": f"{license}{i}", "version": f"{version}{i}"} for i in range(0, number_of_packages)
     ]
     mocker.patch("pylic.cli.commands.list.read_all_installed_licenses_metadata", return_value=license_metadata)
-    return_code = list_commandd.handle([])
+    return_code = list_command.handle([])
     assert return_code == 0
     packages = list(map(lambda line: cast(str, line[0][0].split(" ")[0]), console_writer.line.call_args_list))
     for i in range(0, number_of_packages - 1):

--- a/tests/unit_tests/cli/commands/version_test.py
+++ b/tests/unit_tests/cli/commands/version_test.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from pylic.__version__ import version
+from pylic.cli.commands import version as version_module
+from pylic.cli.commands.version import VersionCommand
+
+
+@pytest.fixture
+def console_writer(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch.object(version_module, "console_writer")
+
+
+def test_version(version_command: VersionCommand, console_writer: MagicMock) -> None:
+    return_code = version_command.handle([])
+    assert return_code == 0
+    console_writer.line.assert_called_once()
+    line = console_writer.line.call_args_list[0][0][0]
+    assert "Pylic version" in line
+    assert version in line

--- a/tests/unit_tests/cli/conftest.py
+++ b/tests/unit_tests/cli/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+from pylic.cli.commands.check import CheckCommand
+from pylic.cli.commands.help import HelpCommand
+from pylic.cli.commands.list import ListCommand
+from pylic.cli.commands.version import VersionCommand
+from pylic.cli.console_reader import ConsoleReader
+
+
+@pytest.fixture
+def console_reader(help_command: HelpCommand) -> ConsoleReader:
+    return ConsoleReader(commands=[help_command])
+
+
+@pytest.fixture
+def check_command() -> CheckCommand:
+    return CheckCommand()
+
+
+@pytest.fixture
+def help_command() -> HelpCommand:
+    return HelpCommand()
+
+
+@pytest.fixture
+def list_command() -> ListCommand:
+    return ListCommand()
+
+
+@pytest.fixture
+def version_command() -> VersionCommand:
+    return VersionCommand()

--- a/tests/unit_tests/cli/console_reader_test.py
+++ b/tests/unit_tests/cli/console_reader_test.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from pylic.cli import console_reader as console_reader_module
+from pylic.cli.console_reader import ConsoleReader
+
+
+@pytest.fixture
+def console_writer(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch.object(console_reader_module, "console_writer")
+
+
+def test_no_such_command(console_writer: MagicMock, console_reader: ConsoleReader) -> None:
+    with pytest.raises(SystemExit):
+        console_reader.get_program(["bogus"])
+    console_writer.write_no_such_command.assert_called_with("bogus")
+
+
+def test_no_such_option(console_writer: MagicMock, console_reader: ConsoleReader) -> None:
+    with pytest.raises(SystemExit):
+        console_reader.get_program(["--bogus"])
+    console_writer.write_no_such_option.assert_called_with("--bogus")

--- a/tests/unit_tests/license_checker_test.py
+++ b/tests/unit_tests/license_checker_test.py
@@ -186,3 +186,23 @@ def test_correct_unsafe_licenses_are_found(package: str, license: str, version: 
     unsafe_licenses = checker.get_unsafe_licenses()
     assert len(unsafe_licenses) == 3
     assert unsafe_licenses == bad_licenses
+
+
+def test_correct_unsafe_licenses_are_found_when_packages_ignored(package: str, license: str, version: str) -> None:
+    bad_licenses = [
+        {"license": f"{license}1", "package": f"{package}1", "version": f"{version}1"},
+        {"license": f"{license}3", "package": f"{package}3", "version": f"{version}3"},
+        {"license": f"{license}4", "package": f"{package}4", "version": f"{version}4"},
+    ]
+    ignore_packages = [f"{package}1"]
+    checker = LicenseChecker(
+        safe_licenses=[f"{license}2"],
+        ignore_packages=ignore_packages,
+        installed_licenses=[
+            *bad_licenses,
+            {"license": f"{license}2", "package": package, "version": f"{version}2"},
+        ],
+    )
+    unsafe_licenses = checker.get_unsafe_licenses()
+    assert len(unsafe_licenses) == 2
+    assert all(license in unsafe_licenses for license in bad_licenses if license["package"] not in ignore_packages)

--- a/tests/unit_tests/license_checker_test.py
+++ b/tests/unit_tests/license_checker_test.py
@@ -1,4 +1,5 @@
 from pylic.license_checker import LicenseChecker
+from pylic.toml import AppConfig
 
 
 def test_no_unncessary_licenses_found_if_no_safe_nor_installed_licenses_present() -> None:
@@ -17,7 +18,7 @@ def test_no_unncessary_licenses_found_if_no_safe_licenses_provided(license: str)
 
 def test_all_licenses_unnecessary_if_no_installed_licenses_found(license: str) -> None:
     safe_licenses = [f"{license}1", f"{license}2", f"{license}3"]
-    checker = LicenseChecker(safe_licenses=safe_licenses)
+    checker = LicenseChecker(AppConfig(safe_licenses=safe_licenses))
     unnecessary_safe_licenses = checker.get_unnecessary_safe_licenses()
     assert unnecessary_safe_licenses == safe_licenses
 
@@ -25,7 +26,7 @@ def test_all_licenses_unnecessary_if_no_installed_licenses_found(license: str) -
 def test_correct_unnecessary_safe_licenses_found(license: str) -> None:
     safe_licenses = [f"{license}2", f"{license}3"]
     installed_licenses = [{"license": f"{license}1"}, {"license": f"{license}2"}]
-    checker = LicenseChecker(safe_licenses=safe_licenses, installed_licenses=installed_licenses)
+    checker = LicenseChecker(AppConfig(safe_licenses=safe_licenses), installed_licenses=installed_licenses)
     unnecessary_safe_licenses = checker.get_unnecessary_safe_licenses()
     assert len(unnecessary_safe_licenses) == 1
     assert unnecessary_safe_licenses == [f"{license}3"]
@@ -45,7 +46,7 @@ def test_no_unncessary_packages_found_if_no_unsafe_packages_provided(package: st
 
 def test_all_packages_unnecessary_if_no_installed_packages_found(package: str) -> None:
     unsafe_packages = [f"{package}1", f"{package}2", f"{package}3"]
-    checker = LicenseChecker(unsafe_packages=unsafe_packages)
+    checker = LicenseChecker(AppConfig(unsafe_packages=unsafe_packages))
     unnecessary_unsafe_packages = checker.get_unnecessary_unsafe_packages()
     assert unnecessary_unsafe_packages == unsafe_packages
 
@@ -53,7 +54,7 @@ def test_all_packages_unnecessary_if_no_installed_packages_found(package: str) -
 def test_correct_unnecessary_unsafe_packages_found(package: str) -> None:
     unsafe_packages = [f"{package}2", f"{package}3"]
     installed_licenses = [{"package": f"{package}1"}, {"package": f"{package}2"}]
-    checker = LicenseChecker(unsafe_packages=unsafe_packages, installed_licenses=installed_licenses)
+    checker = LicenseChecker(AppConfig(unsafe_packages=unsafe_packages), installed_licenses=installed_licenses)
     unnecessary_unsafe_packages = checker.get_unnecessary_unsafe_packages()
     assert len(unnecessary_unsafe_packages) == 1
     assert unnecessary_unsafe_packages == [f"{package}3"]
@@ -78,7 +79,7 @@ def test_no_bad_unsafe_packages_if_no_unsafe_packages_are_provided(package: str,
 
 def test_no_bad_unsafe_packages_if_all_licenses_of_unsafe_packages_come_with_unknown_license(package: str, version: str) -> None:
     checker = LicenseChecker(
-        unsafe_packages=[f"{package}1", f"{package}2"],
+        AppConfig(unsafe_packages=[f"{package}1", f"{package}2"]),
         installed_licenses=[
             {"package": f"{package}1", "license": "unknown"},
             {"package": f"{package}2", "license": "unknown"},
@@ -91,7 +92,7 @@ def test_no_bad_unsafe_packages_if_all_licenses_of_unsafe_packages_come_with_unk
 def test_correct_bad_unsafe_packages_found(package: str, version: str) -> None:
     known_license = {"package": f"{package}1", "license": "not-uknown", "version": version}
     checker = LicenseChecker(
-        unsafe_packages=[f"{package}1", f"{package}2"],
+        AppConfig(unsafe_packages=[f"{package}1", f"{package}2"]),
         installed_licenses=[
             known_license,
             {"package": f"{package}2", "license": "unknown"},
@@ -110,7 +111,7 @@ def test_no_missing_unsafe_packages_if_no_unsafe_packages_are_provided_or_instal
 
 def test_no_missing_unsafe_packages_if_corresponding_unsafe_packages_are_provided(package: str) -> None:
     checker = LicenseChecker(
-        unsafe_packages=[f"{package}1", f"{package}2"],
+        AppConfig(unsafe_packages=[f"{package}1", f"{package}2"]),
         installed_licenses=[
             {"package": f"{package}1", "license": "unknown"},
             {"package": f"{package}2", "license": "unknown"},
@@ -133,7 +134,7 @@ def test_no_missing_unsafe_packages_if_unsafe_packages_are_missing_but_licenses_
 
 def test_correct_missing_unsafe_packages_found(package: str, version: str) -> None:
     checker = LicenseChecker(
-        unsafe_packages=[f"{package}1", f"{package}3"],
+        AppConfig(unsafe_packages=[f"{package}1", f"{package}3"]),
         installed_licenses=[
             {"package": f"{package}1", "license": "not-unknown", "version": f"{version}1"},
             {"package": f"{package}2", "license": "unknown", "version": f"{version}2"},
@@ -148,18 +149,18 @@ def test_correct_missing_unsafe_packages_found(package: str, version: str) -> No
 def test_all_licenses_are_valied_if_no_packages_installed() -> None:
     checker = LicenseChecker()
     unsafe_licenses = checker.get_unsafe_licenses()
-    assert len(unsafe_licenses) == 0
+    assert len(unsafe_licenses.found) == 0
 
 
 def test_unknown_licenses_are_not_considered_unsafe_per_se(package: str) -> None:
     checker = LicenseChecker(installed_licenses=[{"license": "unknown", "package": package}])
     unsafe_licenses = checker.get_unsafe_licenses()
-    assert len(unsafe_licenses) == 0
+    assert len(unsafe_licenses.found) == 0
 
 
 def test_all_licenses_are_valid_if_are_listed_as_safe(package: str, license: str) -> None:
     checker = LicenseChecker(
-        safe_licenses=[f"{license}1", f"{license}2", f"{license}3"],
+        AppConfig(safe_licenses=[f"{license}1", f"{license}2", f"{license}3"]),
         installed_licenses=[
             {"license": f"{license}1", "package": f"{package}1"},
             {"license": f"{license}2", "package": f"{package}2"},
@@ -167,7 +168,7 @@ def test_all_licenses_are_valid_if_are_listed_as_safe(package: str, license: str
         ],
     )
     unsafe_licenses = checker.get_unsafe_licenses()
-    assert len(unsafe_licenses) == 0
+    assert len(unsafe_licenses.found) == 0
 
 
 def test_correct_unsafe_licenses_are_found(package: str, license: str, version: str) -> None:
@@ -177,15 +178,15 @@ def test_correct_unsafe_licenses_are_found(package: str, license: str, version: 
         {"license": f"{license}4", "package": package, "version": f"{version}4"},
     ]
     checker = LicenseChecker(
-        safe_licenses=[f"{license}2"],
+        AppConfig(safe_licenses=[f"{license}2"]),
         installed_licenses=[
             *bad_licenses,
             {"license": f"{license}2", "package": package, "version": f"{version}2"},
         ],
     )
     unsafe_licenses = checker.get_unsafe_licenses()
-    assert len(unsafe_licenses) == 3
-    assert unsafe_licenses == bad_licenses
+    assert len(unsafe_licenses.found) == 3
+    assert unsafe_licenses.found == bad_licenses
 
 
 def test_correct_unsafe_licenses_are_found_when_packages_ignored(package: str, license: str, version: str) -> None:
@@ -196,13 +197,12 @@ def test_correct_unsafe_licenses_are_found_when_packages_ignored(package: str, l
     ]
     ignore_packages = [f"{package}1"]
     checker = LicenseChecker(
-        safe_licenses=[f"{license}2"],
-        ignore_packages=ignore_packages,
+        AppConfig(safe_licenses=[f"{license}2"], ignore_packages=ignore_packages),
         installed_licenses=[
             *bad_licenses,
             {"license": f"{license}2", "package": package, "version": f"{version}2"},
         ],
     )
     unsafe_licenses = checker.get_unsafe_licenses()
-    assert len(unsafe_licenses) == 2
-    assert all(license in unsafe_licenses for license in bad_licenses if license["package"] not in ignore_packages)
+    assert len(unsafe_licenses.found) == 2
+    assert all(license in unsafe_licenses.found for license in bad_licenses if license["package"] not in ignore_packages)

--- a/tests/unit_tests/toml_test.py
+++ b/tests/unit_tests/toml_test.py
@@ -17,13 +17,18 @@ def test_correct_exception_raised_if_toml_file_contains_invalid_content() -> Non
 
 
 def test_no_licenses_safe_if_no_pylic_tool_section_in_toml_file_found() -> None:
-    safe_licenses, _ = read_config("tests/unit_tests/test_tomls/empty.toml")
+    safe_licenses, _, _ = read_config("tests/unit_tests/test_tomls/empty.toml")
     assert len(safe_licenses) == 0
 
 
 def test_no_packages_unsafe_if_no_pylic_tool_section_in_toml_file_found() -> None:
-    _, unsafe_packages = read_config("tests/unit_tests/test_tomls/empty.toml")
+    _, unsafe_packages, _ = read_config("tests/unit_tests/test_tomls/empty.toml")
     assert len(unsafe_packages) == 0
+
+
+def test_no_packages_ignored_if_no_pylic_tool_section_in_toml_file_found() -> None:
+    _, _, ignore_packages = read_config("tests/unit_tests/test_tomls/empty.toml")
+    assert len(ignore_packages) == 0
 
 
 def test_unknown_license_can_not_be_safe() -> None:

--- a/tests/unit_tests/toml_test.py
+++ b/tests/unit_tests/toml_test.py
@@ -17,18 +17,18 @@ def test_correct_exception_raised_if_toml_file_contains_invalid_content() -> Non
 
 
 def test_no_licenses_safe_if_no_pylic_tool_section_in_toml_file_found() -> None:
-    safe_licenses, _, _ = read_config("tests/unit_tests/test_tomls/empty.toml")
-    assert len(safe_licenses) == 0
+    config = read_config("tests/unit_tests/test_tomls/empty.toml")
+    assert len(config.safe_licenses) == 0
 
 
 def test_no_packages_unsafe_if_no_pylic_tool_section_in_toml_file_found() -> None:
-    _, unsafe_packages, _ = read_config("tests/unit_tests/test_tomls/empty.toml")
-    assert len(unsafe_packages) == 0
+    config = read_config("tests/unit_tests/test_tomls/empty.toml")
+    assert len(config.unsafe_packages) == 0
 
 
 def test_no_packages_ignored_if_no_pylic_tool_section_in_toml_file_found() -> None:
-    _, _, ignore_packages = read_config("tests/unit_tests/test_tomls/empty.toml")
-    assert len(ignore_packages) == 0
+    config = read_config("tests/unit_tests/test_tomls/empty.toml")
+    assert len(config.ignore_packages) == 0
 
 
 def test_unknown_license_can_not_be_safe() -> None:


### PR DESCRIPTION
This PR adds a new configuration option which takes a list of package names. If these packages are found to be unsafe due to their license not being listed in `safe_licenses`, they will not be reported as unsafe, nor will the exit code of `pylic` be changed to a non-zero status simply because of the presence of ignored packages that would otherwise be unsafe if not ignored.

The use case for this feature is existing codebases that are in the process of integrating automated license checking with `pylic`. Projects that want to use `pylic` ASAP to protect against new dependencies with unsafe licenses being added. Such a project would, over time, like to eliminate existing unsafe dependencies while avoiding adding new ones.

However such a project can not add `pylic` to their CI/CD pipeline now without blocking all future pipelines. Because if the project currently has even one dependency with an unsafe license, this will cause `pylic` to fail, and therefore fail the pipeline.

There are two existing options for such a project:
1. Temporarily add the unsafe license to the list of safe licenses so that the pipeline passes. This is undesirable because now you will have to keep track of which licenses are actually safe and which ones are just in the list of safe licenses until they can be removed in the future. This is confusing and requires external bookkeeping.
2. Allow the pipeline to pass even if `pylic` returns a non-zero exit code. This is undesirable because if a developer then adds a new package with an unsafe license, they will not be alerted to this fact by the pipeline failing.

Since both of these options are not ideal, I've added the `ignore_packages` config. This will allow the project in our example to ignore these known unsafe dependencies as they are resolved over time. And in the mean time `pylic` provides a defense against the addition of new unsafe packages.