### PR TITLE
write_all_licenses_ok when using extra licenses or packages

### DIFF
--- a/.github/workflows/python-version-integration-tests.yml
+++ b/.github/workflows/python-version-integration-tests.yml
@@ -27,14 +27,14 @@ jobs:
       run: |
         cat <<EOT >> pyproject.toml
         [tool.pylic]
-        safe_licenses = ["Apache Software License", "MIT License", "Python Software Foundation License", "BSD License"]
+        safe_licenses = ["Apache Software License", "MIT License", "Python Software Foundation License"]
         EOT
     - name: Create pyproject.toml and fill it with the necessary config (>= python 3.8)
       if: ${{ matrix.python-version == 3.8 || matrix.python-version == 3.9 || matrix.python-version == 3.10 || matrix.python-version == 3.11 }}
       run: |
         cat <<EOT >> pyproject.toml
         [tool.pylic]
-        safe_licenses = ["Apache Software License", "MIT License", "BSD License"]
+        safe_licenses = ["Apache Software License", "MIT License"]
         EOT
     - name: Test with Python ${{ matrix.python-version }}
       run: |

--- a/pylic/cli/commands/check.py
+++ b/pylic/cli/commands/check.py
@@ -94,6 +94,7 @@ class CheckCommand(Command):
                     or (not unnecessary_unsafe_packages and extra_licenses_declared_and_allowed)
                     or (extra_licenses_declared_and_allowed and extra_packages_declared_and_allowed)
                 ):
+                    console_writer.write_all_licenses_ok()
                     return 0
 
             return 1


### PR DESCRIPTION
The arguments `--allow-extra-safe-licenses` and `--allow-extra-unused-packages` set the return code to 0 but do not write `console_writer.write_all_licenses_ok()`. This is confusing since for a user (without checking the return code) the arguments have no obvious impact.