### PR TITLE
Add initial support for PEP-639

### DIFF
--- a/pylic/licenses.py
+++ b/pylic/licenses.py
@@ -7,7 +7,10 @@ def read_all_installed_licenses_metadata() -> List[Dict]:
 
     installed_licenses: List[Dict] = []
     for distribution in installed_distributions:
-        license_string = _read_license_from_classifier(distribution)
+        license_string = _read_license_expression_from_metadata(distribution)
+
+        if license_string == "unknown":
+            license_string = _read_license_from_classifier(distribution)
         if license_string == "unknown":
             license_string = _read_license_from_metadata(distribution)
         if license_string == "OSI Approved":
@@ -31,4 +34,8 @@ def _read_license_from_classifier(distribution: Distribution) -> str:
 
 
 def _read_license_from_metadata(distribution: Distribution, fallback: str = "unknown") -> str:
-    return distribution.metadata.get("License", fallback)  # type:ignore
+    return distribution.metadata.get("License", fallback)  # type:ignore[no-any-return,attr-defined]
+
+
+def _read_license_expression_from_metadata(distribution: Distribution, fallback: str = "unknown") -> str:
+    return distribution.metadata.get("License-Expression", fallback)  # type:ignore[no-any-return,attr-defined]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ test = "pytest --cov=./ --cov-report=xml"
 safe_licenses = [
   "BSD License",
   "Apache Software License",
+  "MIT",
   "MIT License",
   "Python Software Foundation License"
 ]

--- a/tests/integration_tests/test_tomls/valid.toml
+++ b/tests/integration_tests/test_tomls/valid.toml
@@ -2,6 +2,7 @@
 safe_licenses = [
     "BSD License",
     "Apache Software License",
+    "MIT",
     "MIT License",
     "Python Software Foundation License",
     "GNU Lesser General Public License v3 (LGPLv3)"


### PR DESCRIPTION
Fixes #124

As mentionned in the ticket. This is a naive implementation but supporting SPDX feels out-of-scope for now.